### PR TITLE
Fix `BUILD_DATE` build time env variable being `undefined` at runtime

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,5 +3,8 @@ const { withPlausibleProxy } = require('next-plausible');
 
 /** @type {import('next').NextConfig} */
 module.exports = withPlausibleProxy()({
+  env: {
+    BUILD_DATE: process.env.BUILD_DATE,
+  },
   reactStrictMode: true,
 });


### PR DESCRIPTION
https://nextjs.org/docs/api-reference/next.config.js/environment-variables
