### PR TITLE
Fix unauthenticated access to auth requiring APIs resulting in 500 error

### DIFF
--- a/src/lib-server/apiHelpers.ts
+++ b/src/lib-server/apiHelpers.ts
@@ -66,8 +66,12 @@ export const getIdFromReq = (req: NextApiRequest): string => {
   throw new Error(`Invalid id param in route: ${id}`);
 };
 
+export const safeGetSessionUser = async (req: NextApiRequest): Promise<SessionUser | null> => {
+  return (await getSession({ req }))?.user ?? null;
+};
+
 export const getSessionUser = async (req: NextApiRequest): Promise<SessionUser> => {
-  const user = (await getSession({ req }))?.user;
+  const user = await safeGetSessionUser(req);
   if (!user) {
     throw new UnauthorizedApiError();
   }

--- a/src/lib-server/middleware.ts
+++ b/src/lib-server/middleware.ts
@@ -1,9 +1,14 @@
-import { getSessionUser } from 'lib-server/apiHelpers';
+import { safeGetSessionUser } from 'lib-server/apiHelpers';
+import { sendUnauthorized } from 'lib-server/responses';
 import type { ApiHandler } from 'lib-server/types';
 
 export const withAuthRequired = <T extends ApiHandler>(handler: T) => {
   return async (req: Parameters<T>[0], res: Parameters<T>[1]): Promise<void> => {
-    await getSessionUser(req); // Throws an error if not authorized.
-    await handler(req, res);
+    const user = await safeGetSessionUser(req);
+    if (!user) {
+      sendUnauthorized(res);
+    } else {
+      await handler(req, res);
+    }
   };
 };


### PR DESCRIPTION
Reason was that the `withAuthRequired` middleware could be (and was)
placed outside the `makeMethodsHandler` factory function, and thus the
API handler that `makeMethodsHandler` returns could not catch the
`UnauthorizedApiError` that `withAuthRequired` would throw.
