### PR TITLE
Remove useless imports from `types.d.ts`

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,6 +1,3 @@
-import NextAuth from 'next-auth'; // eslint-disable-line @typescript-eslint/no-unused-vars
-import types from 'next-auth/jwt/types'; // eslint-disable-line @typescript-eslint/no-unused-vars
-
 import type { SessionUser } from 'lib-server/types';
 
 declare module 'next-auth' {


### PR DESCRIPTION
They didn't actually do anything. It was likely just accidentally
imported here in the example:
https://github.com/nextauthjs/next-auth/discussions/536#discussioncomment-1487674
