### PR TITLE
Make Vercel run `prisma generate` before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "generate": "prisma generate",
     "dev": "next dev",
     "build": "BUILD_DATE=\"$(date '+%Y-%m-%d')\" next build",
-    "vercel:build": "yarn build && if [ \"$VERCEL_ENV\" == 'preview' ]; then yarn migrate:reset; else yarn migrate:deploy; fi",
+    "vercel:build": "yarn generate && yarn build && if [ \"$VERCEL_ENV\" == 'preview' ]; then yarn migrate:reset; else yarn migrate:deploy; fi",
     "start": "next start",
     "format": "prettier --write '**/*.{ts,tsx,js,json,css,prisma}' && eslint --fix --max-warnings=0 --ext=.ts,.tsx,.js .",
     "lint": "prettier --check '**/*.{ts,tsx,js,json,css,prisma}' && eslint --max-warnings=0 --ext=.ts,.tsx,.js . && yarn dpdm --tree=false --exit-code=circular:1 $(find src/)",


### PR DESCRIPTION
Otherwise, we might get old cached Prisma client typings.
