### PR TITLE
Improve metrics visualization

### DIFF
--- a/src/components/dashboard/RequestsOverview.tsx
+++ b/src/components/dashboard/RequestsOverview.tsx
@@ -14,7 +14,7 @@ import {
   WEEK_DAYS,
   YEAR_DAYS,
 } from 'utils/constants';
-import { getDatesBetweenTimeFrame, getTimeFrameScope } from 'utils/metrics';
+import { getDataPointsBetweenTimeFrame, getTimeFrameScope } from 'utils/metrics';
 import type { OriginMetrics, TimeFrame, TimeFrameData } from 'types';
 
 const HOUR_FORMAT = 'h A';
@@ -37,7 +37,7 @@ export const RequestsOverview: React.FC<Props> = ({
   const scope = getTimeFrameScope(timeFrame);
 
   // Make sure the data contains points in time for the whole specified time frame.
-  const data: TimeFrameData[] = getDatesBetweenTimeFrame(timeFrame).map((time) => {
+  const data: TimeFrameData[] = getDataPointsBetweenTimeFrame(timeFrame).map((time) => {
     const data = timeFrameData.find((data) => dayjs(data.time).startOf(scope).format() === time);
 
     return {
@@ -108,11 +108,11 @@ export const RequestsOverview: React.FC<Props> = ({
 
   const getTotalRequests = (): string => {
     if (totalRequests > 1_000_000) {
-      return `${(totalRequests / 100).toFixed(1)}k`;
+      return `${(totalRequests / 1_000_000).toFixed(1)}m`;
     }
 
     if (totalRequests > 1_000) {
-      return `${(totalRequests / 100).toFixed(1)}k`;
+      return `${(totalRequests / 1_000).toFixed(1)}k`;
     }
 
     return `${totalRequests}`;

--- a/src/components/dashboard/ResponseTimes.tsx
+++ b/src/components/dashboard/ResponseTimes.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Bar,
   BarChart,
@@ -22,18 +22,15 @@ interface Props {
 
 // TODO: All of the commented parts are needed when we enable the color coding of the response times.
 export const ResponseTimes: React.FC<Props> = ({ metrics: { routeData }, loading }) => {
-  // The data must be kept in state for the labels to work: https://github.com/recharts/recharts/issues/829#issuecomment-458815276
-  const [data] = useState(() =>
-    routeData
-      .sort((a, b) => (a.response_time < b.response_time ? 1 : -1))
-      .map(({ response_time, ...routeData }) => ({
-        ...routeData,
-        response_time,
-        greenRequests: (response_time * (routeData.count_green / routeData.requests)).toFixed(),
-        yellowRequests: (response_time * (routeData.count_yellow / routeData.requests)).toFixed(),
-        redRequests: (response_time * (routeData.count_red / routeData.requests)).toFixed(),
-      })),
-  );
+  const data = routeData
+    .sort((a, b) => (a.response_time < b.response_time ? 1 : -1))
+    .map(({ response_time, ...routeData }) => ({
+      ...routeData,
+      response_time,
+      greenRequests: (response_time * (routeData.count_green / routeData.requests)).toFixed(),
+      yellowRequests: (response_time * (routeData.count_yellow / routeData.requests)).toFixed(),
+      redRequests: (response_time * (routeData.count_red / routeData.requests)).toFixed(),
+    }));
 
   const renderResponseTimeLabels = (
     <RouteValue formatter={(value?: string | number): string => `${value}ms`} />

--- a/src/components/dashboard/RouteMetrics.tsx
+++ b/src/components/dashboard/RouteMetrics.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Bar,
   BarChart,
@@ -21,10 +21,7 @@ interface Props {
 }
 
 export const RouteMetrics: React.FC<Props> = ({ metrics: { routeData }, loading }) => {
-  // The data must be kept in state for the labels to work: https://github.com/recharts/recharts/issues/829#issuecomment-458815276
-  const [data] = useState(() =>
-    routeData.sort((a, b) => (a.requests < b.requests ? 1 : -1)).map((c) => c),
-  );
+  const data = routeData.sort((a, b) => (a.requests < b.requests ? 1 : -1));
 
   const renderRequestLabels = (
     <RouteValue

--- a/src/pages/api/origins/[slug]/metrics.ts
+++ b/src/pages/api/origins/[slug]/metrics.ts
@@ -6,7 +6,7 @@ import { withApilytics } from 'utils/apilytics';
 import type { ApiHandler, OriginMetrics, RouteData, TimeFrameData } from 'types';
 
 const DAY_MILLIS = 24 * 60 * 60 * 1000;
-const SIX_MONTHS_MILLIS = 6 * 30 * DAY_MILLIS;
+const THREE_MONTHS_MILLIS = 3 * 30 * DAY_MILLIS;
 
 interface GetResponse {
   data: OriginMetrics;
@@ -42,7 +42,7 @@ const handleGet: ApiHandler<GetResponse> = async (req, res) => {
 
   if (timeFrame <= DAY_MILLIS) {
     scope = 'hour';
-  } else if (timeFrame >= SIX_MONTHS_MILLIS) {
+  } else if (timeFrame >= THREE_MONTHS_MILLIS) {
     scope = 'week';
   }
 


### PR DESCRIPTION
- Draw graph already from three month time
frame instead of the previous six month threshold.
- Generate demo data so that the time frame data
matches with the route metrics.
- Fix decimals in the total requests indicator.