### PR TITLE
Reserve 192MB of RAM for each serverless function

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "functions": {
+    "src/pages/api/**": {
+      "memory": 192
+    }
+  },
+  "regions": ["fra1"]
+}


### PR DESCRIPTION
The default was 1024MB, we likely don't need nearly as much.

Also, specify Frankfurt as the region for the functions as our DB is
there.
