### PR TITLE
Add request and response sizes to Metric model and middleware API

### DIFF
--- a/prisma/migrations/20220124173418_metrics_request_response_size/migration.sql
+++ b/prisma/migrations/20220124173418_metrics_request_response_size/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "metrics" ADD COLUMN     "request_size" BIGINT,
+ADD COLUMN     "response_size" BIGINT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,15 +82,17 @@ model OriginRoute {
 }
 
 model Metric {
-  id          String @id @default(uuid()) @db.Uuid
-  path        String
-  queryParams Json?  @map("query_params")
-  method      String
+  id           String  @id @default(uuid()) @db.Uuid
+  path         String
+  queryParams  Json?   @map("query_params")
+  method       String
   // Can't be nullable because we need to use `ARRAY_AGG` on this: https://github.com/prisma/prisma/issues/11339
   // Value 0 indicates that we didn't get a response status code from the middleware, can happen
   // e.g. when an inner request handler function that the middleware wraps throws an error.
-  statusCode  Int    @default(0) @map("status_code")
-  timeMillis  Int    @map("time_millis")
+  statusCode   Int     @default(0) @map("status_code")
+  timeMillis   Int     @map("time_millis")
+  requestSize  BigInt? @map("request_size")
+  responseSize BigInt? @map("response_size")
 
   apilyticsVersion String? @map("apilytics_version")
 

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -54,6 +54,14 @@ paths:
                     This accepts a `null` value as well, which currently behaves the same as if this were omitted.
                     Sending a `null` value is deprecated and future code should simply omit this from the payload.
                   example: 200
+                requestSize:
+                  type: integer
+                  description: Size of the user's HTTP request's body in bytes.
+                  example: 1024
+                responseSize:
+                    type: integer
+                  description: Size of the body of the sent HTTP response in bytes.
+                  example: 2048
                 timeMillis:
                   type: integer
                   description: The amount of time in milliseconds it took to respond to the user's request.

--- a/src/pages/api/v1/middleware.ts
+++ b/src/pages/api/v1/middleware.ts
@@ -18,7 +18,10 @@ type RequiredFields = Pick<Metric, 'path' | 'method' | 'timeMillis'>;
 type OptionalFields = {
   query?: 'string';
   statusCode?: number | null; // Nullable for backwards compatibility.
+  requestSize?: number;
+  responseSize?: number;
 };
+
 type PostBody = RequiredFields & OptionalFields;
 
 const handlePost: ApiHandler = async (req, res) => {
@@ -51,7 +54,8 @@ const handlePost: ApiHandler = async (req, res) => {
     return;
   }
 
-  const { path, query, method, statusCode, timeMillis } = req.body as PostBody;
+  const { path, query, method, statusCode, timeMillis, requestSize, responseSize } =
+    req.body as PostBody;
 
   const queryParams = query ? Object.fromEntries(new URLSearchParams(query)) : undefined;
 
@@ -68,6 +72,8 @@ const handlePost: ApiHandler = async (req, res) => {
       method,
       statusCode: statusCode ?? UNKNOWN_STATUS_CODE,
       timeMillis,
+      requestSize,
+      responseSize,
       apilyticsVersion,
     },
   });


### PR DESCRIPTION
Atm rebased on top of #95, it should be merged first.