### PR TITLE
Fix `20220124165911_non_nullable_status_code` migration failing in prod

### DIFF
--- a/prisma/migrations/20220124165911_non_nullable_status_code/migration.sql
+++ b/prisma/migrations/20220124165911_non_nullable_status_code/migration.sql
@@ -1,2 +1,3 @@
 ALTER TABLE "metrics" ALTER COLUMN "status_code" SET DEFAULT 0;
+UPDATE "metrics" SET "status_code" = 0 WHERE "status_code" IS NULL;
 ALTER TABLE "metrics" ALTER COLUMN "status_code" SET NOT NULL;


### PR DESCRIPTION
Failed in
https://vercel.com/apilytics/apilytics/A2mDRwRCgribj8CQKmfn19RsxZGo,
with:
```
Error: P3018

A migration failed to apply. New migrations cannot be applied before the
error is recovered from. Read more about how to resolve migration issues
in a production database: https://pris.ly/d/migrate-resolve

Migration name: 20220124165911_non_nullable_status_code

Database error code: 23502

Database error:
ERROR: column "status_code" contains null values
```
