### PR TITLE
Add error logging to middleware API to debug weird Prisma prod errors

### DIFF
--- a/src/pages/api/v1/middleware.ts
+++ b/src/pages/api/v1/middleware.ts
@@ -38,6 +38,9 @@ const handlePost: ApiHandler = async (req, res) => {
     origin = await prisma.origin.findUnique({ where: { apiKey } });
   } catch (e) {
     if (!isInconsistentColumnData(e)) {
+      console.error('Prisma error, req path:', req.url);
+      console.error('Prisma error, req headers:', req.headers);
+      console.error('Prisma error, req body:', req.body);
       throw e;
     }
     // Was not a valid UUID.


### PR DESCRIPTION
Trying to debug this error that Logalert tells us about around once per
day:
```
500 /api/v1/middleware
2022-01-25T00:03:15.654Z		ERROR	PrismaClientKnownRequestError:
Invalid `prisma.origin.findUnique()` invocation:
  Unauthorized, check your connection string
    at cb (/var/task/node_modules/@prisma/client/runtime/proxy.js:94:56)
    at runMicrotasks ()
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async handlePost (/var/task/.next/server/pages/api/v1/middleware.js:47:18)
    at async /var/task/.next/server/chunks/6831.js:33:21
    at async Object.apiResolver (/var/task/node_modules/next/dist/server/api-utils.js:102:9)
    at async Server.handleApiRequest (/var/task/node_modules/next/dist/server/next-server.js:1064:9)
    at async Object.fn (/var/task/node_modules/next/dist/server/next-server.js:951:37)
    at async Router.execute (/var/task/node_modules/next/dist/server/router.js:222:32)
    at async Server.run (/var/task/node_modules/next/dist/server/next-server.js:1135:29) {
  code: 'P5007',
  clientVersion: '3.8.1',
  meta: undefined
}
```
