### PR TITLE
Set `requestSize` to 0 when its `undefined` for GET metrics that have `responseSize` set

### DIFF
--- a/src/pages/api/v1/middleware.ts
+++ b/src/pages/api/v1/middleware.ts
@@ -58,8 +58,21 @@ const handlePost: ApiHandler = async (req, res) => {
     return;
   }
 
-  const { path, query, method, statusCode, timeMillis, requestSize, responseSize, userAgent } =
-    req.body as PostBody;
+  const {
+    path,
+    query,
+    method,
+    statusCode,
+    timeMillis,
+    requestSize: _requestSize,
+    responseSize,
+    userAgent,
+  } = req.body as PostBody;
+
+  const requestSize =
+    _requestSize === undefined && responseSize !== undefined && method.toUpperCase() === 'GET'
+      ? 0
+      : _requestSize;
 
   const queryParams = query ? Object.fromEntries(new URLSearchParams(query)) : undefined;
 


### PR DESCRIPTION
This gives us slightly more complete data.

If the `Content-Length` header is not set, e.g. the Node middlewares
might not get the request body size for GET requests. It's pretty safe
to assume that it was 0 in these cases, since GET requests are not
supposed to have a body at all. Only do this in cases where we do get a
valid `responseSize` in the metric, so we don't end up having millions
of metrics where `requestSize` is 0 and `responseSize` is `null`.
