### PR TITLE
Fix out of memory production error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,8 @@
 {
   "functions": {
+    "src/pages/api/origins/[slug]/metrics.ts": {
+      "memory": 256
+    },
     "src/pages/**": {
       "memory": 192
     }


### PR DESCRIPTION
Should fix this:
```
[GET] /api/origins/api.aniapi.com/metrics?from=2022-01-31:11:06:42&to=2022-02-07:11:06:42
12:06:42:72
Function Status:
None
Edge Status:
500
Duration:
6006.44 ms
Init Duration:
N/A
Memory Used:
192 MB
ID:
fra1:fra1::l7k87-1644228402525-a96036fd32b3
User Agent:
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.81 Safari/537.36
RequestId: 84f62ee1-bc7a-4dbe-b61e-012baa25a894 Error: Runtime exited with error: signal: killed
Runtime.ExitError
```
