### PR TITLE
Revert server-side session fetching

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,12 +4,11 @@ import '@fontsource/ubuntu';
 
 import dayjs from 'dayjs';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
-import App from 'next/app';
-import { getSession, SessionProvider } from 'next-auth/react';
-// Ignore: Fine to import directly from `next-plausible`.
+import { SessionProvider } from 'next-auth/react';
+// Ignore: Fine to import the provider directly from `next-plausible` here.
 // eslint-disable-next-line no-restricted-imports
 import PlausibleProvider from 'next-plausible';
-import type { AppContext, AppInitialProps, AppProps } from 'next/app';
+import type { AppProps } from 'next/app';
 
 import { AccountProvider } from 'context/account';
 import { ModalProvider } from 'context/modal';
@@ -33,18 +32,5 @@ const MyApp = ({ Component, pageProps: { session, ...pageProps } }: AppProps): J
     </SessionProvider>
   </PlausibleProvider>
 );
-
-MyApp.getInitialProps = async (ctx: AppContext): Promise<AppInitialProps> => {
-  const initialProps = await App.getInitialProps(ctx);
-
-  return {
-    ...initialProps,
-    pageProps: {
-      ...initialProps.pageProps,
-      // @ts-ignore: `ctx.req` is an optional parameter in `AppContext` but required by `getSession`.
-      session: await getSession(ctx),
-    },
-  };
-};
 
 export default MyApp;


### PR DESCRIPTION
This is a potential fix the production issue of
`docs.json` not being found and redirection
to origins page not working.