### PR TITLE
Format byte values as kibibytes, mebibytes, and gibibytes

### DIFF
--- a/src/components/dashboard/PercentileMetrics.tsx
+++ b/src/components/dashboard/PercentileMetrics.tsx
@@ -78,8 +78,7 @@ export const PercentileMetrics: React.FC<Props> = ({ data }) => {
       emptyLabel: 'No response sizes available.',
     },
     cpuUsage: {
-      formatter: (value?: string | number): string =>
-        `${((Number(value) ?? 0) * 100).toFixed(1)} %`,
+      formatter: (value?: string | number): string => `${(Number(value ?? 0) * 100).toFixed(1)} %`,
       dataKey: 'cpuUsage',
       label: 'CPU usage',
       emptyLabel: 'No CPU usage available.',


### PR DESCRIPTION
Powers of two are are the de facto way to format storage and memory byte
values. The prefixes are not that standardized, but let us use the
precise IEC 80000-13 definitions leaving no room for any ambiguity.

Further reading:
https://en.wikipedia.org/wiki/Byte#Multiple-byte_units