### PR TITLE
Fix `TypeError: body used already for` error in middleware API

### DIFF
--- a/src/pages/api/v1/middleware.ts
+++ b/src/pages/api/v1/middleware.ts
@@ -146,7 +146,7 @@ const handlePost: ApiHandler = async (req, res) => {
       if (![200, 400].includes(geoIpRes.status)) {
         let message;
         try {
-          message = await geoIpRes.json();
+          message = await geoIpRes.clone().json();
         } catch {
           message = await geoIpRes.text();
         }


### PR DESCRIPTION
Fix from:
https://stevenklambert.com/writing/fetch-json-text-fallback/
https://github.com/node-fetch/node-fetch/issues/533#issuecomment-429261523
