### PR TITLE
Actually fix null bytes in a query string causing 500 error

### DIFF
--- a/src/pages/api/v1/middleware.ts
+++ b/src/pages/api/v1/middleware.ts
@@ -109,7 +109,7 @@ const handlePost: ApiHandler = async (req, res) => {
       : _requestSize;
 
   // eslint-disable-next-line no-control-regex
-  const query = _query?.replace(/\x00/g, ''); // Remove null bytes, as Postgres cannot serialize them into JSON.
+  const query = _query?.replace(/%00/g, '%2500'); // Escape encoded null bytes, as Postgres cannot serialize them into JSON.
   const queryParams = query ? Object.fromEntries(new URLSearchParams(query)) : undefined;
 
   const apilyticsVersion =


### PR DESCRIPTION
It's apparently a thing: https://www.whitehatsec.com/glossary/content/null-byte-injection