### PR TITLE
Fix email report API error

### DIFF
--- a/src/pages/api/origins/email-reports.ts
+++ b/src/pages/api/origins/email-reports.ts
@@ -28,7 +28,7 @@ const handlePost: ApiHandler<MessageResponse> = async (req, res) => {
       OR: [
         {
           lastAutomaticWeeklyEmailReportsSentAt: {
-            lt: lastSundayNight,
+            lt: new Date(lastSundayNight),
           },
         },
         {


### PR DESCRIPTION
Casting the date string to a date object fixes the issue.