### PR TITLE
Fix  `add_metric_endpoint` migration

### DIFF
--- a/prisma/migrations/20220730124602_add_metric_endpoint/migration.sql
+++ b/prisma/migrations/20220730124602_add_metric_endpoint/migration.sql
@@ -1,5 +1,7 @@
 -- AlterTable
-ALTER TABLE "metrics" ADD COLUMN     "endpoint" TEXT NOT NULL;
+ALTER TABLE "metrics" ADD COLUMN     "endpoint" TEXT;
+
+ALTER TABLE "metrics" ALTER COLUMN "endpoint" SET NOT NULL;
 
 -- DropIndex
 DROP INDEX "metrics_origin_id_path_method_status_code_browser_os_device_idx";


### PR DESCRIPTION
Forgot that for some reason the nullability
for the colum must be set separately as
setting it directly in the column addition will
result in a failed migration.