### PR TITLE
Fix  `add_metric_endpoint` migration

### DIFF
--- a/prisma/migrations/20220730124602_add_metric_endpoint/migration.sql
+++ b/prisma/migrations/20220730124602_add_metric_endpoint/migration.sql
@@ -1,10 +1,12 @@
 -- AlterTable
-ALTER TABLE "metrics" ADD COLUMN     "endpoint" TEXT;
+ALTER TABLE "metrics" ADD COLUMN     "endpoint" TEXT NOT NULL DEFAULT '';
 
-ALTER TABLE "metrics" ALTER COLUMN "endpoint" SET NOT NULL;
+UPDATE metrics
 
--- DropIndex
-DROP INDEX "metrics_origin_id_path_method_status_code_browser_os_device_idx";
-
--- CreateIndex
-CREATE INDEX "metrics_origin_id_path_endpoint_method_status_code_browser__idx" ON "metrics"("origin_id", "path", "endpoint", "method", "status_code", "browser", "os", "device", "country", "region", "city", "dynamic_route_id", "excluded_route_id", "created_at");
+SET endpoint = (
+    SELECT CASE WHEN route IS NULL THEN metrics.path ELSE route END
+    FROM dynamic_routes
+    WHERE dynamic_routes.id = metrics.dynamic_route_id
+        AND metrics.path IS NOT NULL
+        AND metrics.dynamic_route_id IS NOT NULL
+);


### PR DESCRIPTION
Need to explicitly set the default value for
new hypertable text columns for some reason
based on local testting.

Also, attempt to include the data migration here
again since that wasn't the original problem.